### PR TITLE
Update admin login to use case-insensitive usernames

### DIFF
--- a/table-code/src/app/admin-login/page.tsx
+++ b/table-code/src/app/admin-login/page.tsx
@@ -21,8 +21,9 @@ export default function AdminLogin() {
 
     // Hardcoded admin credentials
     if (
-      (username === "param" && password === "param12north5sea") ||
-      (username === "DavidL" && password === "DavidL12north5sea")
+      (username.toLowerCase() === "param" && password === "param12north5sea") ||
+      (username.toLowerCase() === "davidl@northseatrading.org" &&
+        password === "Medea63263$")
     ) {
       router.push("/dashboard")
       setLoading(false)


### PR DESCRIPTION
Changed the admin login logic to compare usernames in a case-insensitive manner and updated the credentials for 'DavidL' to use an email address and a new password.